### PR TITLE
T-18440 fix: adds missing ability to filter by role in GetLoadBalancersByUserID

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
   pocket-http-db:
     # TO DO - change to master once v1 PR merged
     # build: github.com/pokt-foundation/pocket-http-db.git#master
-    build: github.com/pokt-foundation/pocket-http-db.git#update-v1-to-user-access
+    build: github.com/pokt-foundation/pocket-http-db.git#v1-filter-lbs-by-role
     container_name: pocket-http-db
     restart: always
     ports:


### PR DESCRIPTION
Adds the ability to provide a `RoleName` filter to `GetLoadBalancersByUserID` and adds tests for this filter.

This coincides with the changes to PHD in https://github.com/pokt-foundation/pocket-http-db/pull/100