### PR TITLE
[skip ci] chore: lock precommit installed modules to specific version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ init-pre-commit:
 	wget https://github.com/pre-commit/pre-commit/releases/download/v2.20.0/pre-commit-2.20.0.pyz;
 	python3 pre-commit-2.20.0.pyz install;
 	python3 pre-commit-2.20.0.pyz autoupdate;
-	go install golang.org/x/tools/cmd/goimports@latest;
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest;
-	go install -v github.com/go-critic/go-critic/cmd/gocritic@latest;
+	go install golang.org/x/tools/cmd/goimports@v0.6.0;
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0;
+	go install -v github.com/go-critic/go-critic/cmd/gocritic@v0.6.5;
 	python3 pre-commit-2.20.0.pyz run --all-files;
 	rm pre-commit-2.20.0.pyz;


### PR DESCRIPTION
chore: locks the version of the go modules installed by the make init-pre-commit command to a specific version. WILL NOT RUN CI